### PR TITLE
Switches to a more universal https clone URL

### DIFF
--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -1,7 +1,7 @@
 
  - name: clone RTBkit repo
    git: >
-    repo=git@github.com:rtbkit/rtbkit.git
+    repo=https://github.com/rtbkit/rtbkit.git
     dest={{ rtbkit_framework }}
     recursive=no
     update=yes


### PR DESCRIPTION
This way we don't need any SSH keys and it works behind firewalls/proxies.
